### PR TITLE
increase execution params for browscap

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -14,6 +14,9 @@
 /**
  * This cron script recompiles the Browscap cache
  */
+ini_set('memory_limit','-1');      // turn off memory limit for this script
+set_time_limit(120);               // change to 2 minutes for this script
+
 require('libs/browscap-php/src/phpbrowscap/Browscap.php');
 
 use phpbrowscap\Browscap;
@@ -22,4 +25,3 @@ date_default_timezone_set('America/Chicago');
 
 $browscap = new Browscap('/var/php_cache/browser');
 $browscap->updateCache();
-


### PR DESCRIPTION
receive error when attempting to populate browcap cache on docker instance..

following suggestion for similar error published here
http://stackoverflow.com/questions/24755517/allowed-memory-size-exhausted-in-browscap



<!---
@huboard:{"custom_state":"archived"}
-->
