### PR TITLE
allow setting globals to false

### DIFF
--- a/class.Settings.php
+++ b/class.Settings.php
@@ -44,7 +44,7 @@ class Settings extends \Singleton
 
     public function getGlobalSetting($propName, $default = false)
     {
-        if(isset(FlipsideSettings::$global) && FlipsideSettings::$global[$propName])
+        if(isset(FlipsideSettings::$global) && isset(FlipsideSettings::$global[$propName]))
         {
             return FlipsideSettings::$global[$propName];
         }


### PR DESCRIPTION
checking FlipsideSettings::$global[$propName] when the prop is set to boolean false would always return default

this prevented use from setting use_cdn and use_minified to false 

<!---
@huboard:{"custom_state":"archived"}
-->
