### PR TITLE
allow binddn as RO and RW

### DIFF
--- a/class.Settings.php
+++ b/class.Settings.php
@@ -137,7 +137,7 @@ class Settings extends \Singleton
      *
      * @return mixed The value from the settings file
      */
-    public function getLDAPSetting(string $propName, $ldapAuth = false, $default = false)
+    public function getLDAPSetting($propName, $ldapAuth = false, $default = false)
     {
         switch($propName)
         {
@@ -146,9 +146,17 @@ class Settings extends \Singleton
             default:
                 if($ldapAuth === false)
                 {
-                    return FlipsideSettings::$ldap[$propName];
+                    if(isset(FlipsideSettings::$ldap) && isset(FlipsideSettings::$ldap[$propName]))
+                    {
+                        return FlipsideSettings::$ldap[$propName];
+                    }
+                    return $default;
                 }
-                return FlipsideSettings::$ldap_auth[$propName];
+                if(isset(FlipsideSettings::$ldap_auth) && isset(FlipsideSettings::$ldap_auth[$propName]))
+                {
+                    return FlipsideSettings::$ldap_auth[$propName];
+                }
+                return $default;
         }
     }
 }

--- a/tests/travis/LDAPTest.php
+++ b/tests/travis/LDAPTest.php
@@ -46,7 +46,7 @@ class LDAPTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($res);
         $res = $server->bind('cn=admin,dc=example,dc=com','test');
         $this->assertTrue($res);
-      
+
         $data = $server->read('dc=example,dc=com');
         $this->assertNotFalse($data);
         $this->assertContainsOnlyInstancesOf('LDAP\LDAPObject', $data);
@@ -91,6 +91,8 @@ class LDAPTest extends PHPUnit_Framework_TestCase
         $params['group_base'] = 'dc=example,dc=com';
         $params['bind_dn'] = 'cn=admin,dc=example,dc=com';
         $params['bind_pass'] = 'test';
+        //$params['ro_bind_dn'] = 'cn=readonly,dc=example,dc=com';
+        //$params['ro_bind_pass'] = 'test';
         $auth = new \Auth\LDAPAuthenticator($params);
         $this->assertNotFalse($auth->getAndBindServer());
         $this->assertNotFalse($auth->getAndBindServer(true));


### PR DESCRIPTION
this PR is meant to start the discussion regarding how to properly implement a read only bindDN user for ldap.. 

i imagine these changes are a nice start.. but probably are just the tip..

<!---
@huboard:{"order":29.00580029,"milestone_order":24,"custom_state":""}
-->
