### PR TITLE
Handle google libs reordering query string

### DIFF
--- a/tests/AuthenticatorTest.php
+++ b/tests/AuthenticatorTest.php
@@ -135,7 +135,39 @@ class AuthenticatorTest extends PHPUnit_Framework_TestCase
         $auth = new \Auth\GoogleAuthenticator($params);
         $this->assertNotNull($auth);
         $this->assertInstanceOf('Auth\GoogleAuthenticator', $auth);
-        $this->assertEquals('<a href="https://accounts.google.com/o/oauth2/auth?response_type=code&redirect_uri=https%3A%2F%2Fexample.com%2Foauth2callback.php%3Fsrc%3Dgoogle&client_id=test&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email&access_type=online&approval_prompt=auto"><img src="/img/common/google_sign_in.png" style="width: 2em;"/></a>', $auth->getSupplementLink());
+        $linkTxt = $auth->getSupplementLink();
+        $dom = new DOMDocument;
+        $internalErrors = libxml_use_internal_errors(true);
+        $dom->loadHTML($linkTxt);
+        libxml_use_internal_errors($internalErrors);
+        //HTML element, skip
+        $doc = $dom->documentElement;
+        //Body element, skip
+        $body = $doc->childNodes[0];
+
+        $this->assertEquals($body->childNodes->length, 1);
+        $link = $body->childNodes[0];
+        $this->assertEquals($link->tagName, 'a');
+
+        $attributes = $link->attributes;
+        $this->assertEquals($attributes->length, 1); 
+        $url = parse_url($attributes[0]->value);
+        $this->assertEquals($url['scheme'], 'https');
+        $this->assertEquals($url['host'], 'accounts.google.com');
+        $this->assertEquals($url['path'], '/o/oauth2/auth');
+        parse_str($url['query'], $queryStr);
+        $this->assertArrayHasKey('response_type', $queryStr);
+        $this->assertEquals($queryStr['response_type'], 'code');
+        $this->assertArrayHasKey('access_type', $queryStr);
+        $this->assertEquals($queryStr['access_type'], 'online');
+        $this->assertArrayHasKey('client_id', $queryStr);
+        $this->assertEquals($queryStr['client_id'], 'test');
+        $this->assertArrayHasKey('redirect_uri', $queryStr);
+        $this->assertEquals($queryStr['redirect_uri'], 'https://example.com/oauth2callback.php?src=google');
+        
+        $children = $link->childNodes;
+        $this->assertEquals($children->length, 1);
+        $this->assertEquals($children[0]->tagName, 'img');
     }
 }
 /* vim: set tabstop=4 shiftwidth=4 expandtab: */

--- a/tests/AuthenticatorTest.php
+++ b/tests/AuthenticatorTest.php
@@ -143,15 +143,15 @@ class AuthenticatorTest extends PHPUnit_Framework_TestCase
         //HTML element, skip
         $doc = $dom->documentElement;
         //Body element, skip
-        $body = $doc->childNodes[0];
+        $body = $doc->childNodes->item(0);
 
         $this->assertEquals($body->childNodes->length, 1);
-        $link = $body->childNodes[0];
+        $link = $body->childNodes->item(0);
         $this->assertEquals($link->tagName, 'a');
 
         $attributes = $link->attributes;
         $this->assertEquals($attributes->length, 1); 
-        $url = parse_url($attributes[0]->value);
+        $url = parse_url($attributes->item(0)->value);
         $this->assertEquals($url['scheme'], 'https');
         $this->assertEquals($url['host'], 'accounts.google.com');
         $this->assertEquals($url['path'], '/o/oauth2/auth');
@@ -167,7 +167,7 @@ class AuthenticatorTest extends PHPUnit_Framework_TestCase
         
         $children = $link->childNodes;
         $this->assertEquals($children->length, 1);
-        $this->assertEquals($children[0]->tagName, 'img');
+        $this->assertEquals($children->item(0)->tagName, 'img');
     }
 }
 /* vim: set tabstop=4 shiftwidth=4 expandtab: */


### PR DESCRIPTION
The PHPUnit tests are failing on my dev system because the google libraries are putting the query string parameters in different order. 

<!---
@huboard:{"custom_state":"archived"}
-->
