### PR TITLE
do not async load bootstrap css

### DIFF
--- a/class.FlipPage.php
+++ b/class.FlipPage.php
@@ -483,7 +483,7 @@ class FlipPage extends WebPage
      * @param string $jsFileID the ID of the JS file
      * @param boolean $async Can the JS file be loaded asynchronously?
      */
-    public function addWellKnownJS($jsFileID, $async = true)
+    public function addWellKnownJS($jsFileID, $async = false)
     {
         global $jsArray;
         $this->setupVars();
@@ -497,7 +497,7 @@ class FlipPage extends WebPage
      * @param string $cssFileID the ID of the CSS file
      * @param boolean $async Can the CSS file be loaded asynchronously?
      */
-    public function addWellKnownCSS($cssFileID, $async = true)
+    public function addWellKnownCSS($cssFileID, $async = false)
     {
         global $cssArray;
         $this->setupVars();
@@ -510,9 +510,10 @@ class FlipPage extends WebPage
      */
     private function addBootstrap()
     {
-        $this->addWellKnownJS(JS_BOOTSTRAP, false);
+        $this->addWellKnownJS(JS_BOOTSTRAP);
         $this->addWellKnownCSS(CSS_BOOTSTRAP);
         $this->addWellKnownCSS(CSS_FONTAWESOME);
+
     }
 
     protected function getSiteLinksForHeader()


### PR DESCRIPTION
i can't explain the different behaviors between my local instance and production but here are the symptoms.. i'm using chrome and near as i can tell both instances are running the same version of class.FlipPage.php

local server - bootstrap and font awesome links show rel=import
<img width="219" alt="screenshot 2017-02-21 19 20 06" src="https://cloud.githubusercontent.com/assets/24982262/23193234/7bcf45c6-f86d-11e6-8477-03e6f7a2158c.png">

production server - bootstrap and font awesome show rel=stylesheet
<img width="269" alt="screenshot 2017-02-21 19 19 50" src="https://cloud.githubusercontent.com/assets/24982262/23193233/79765684-f86d-11e6-8858-a2c8e3856287.png">

on both instances if styelsheet links are set to rel=import they do not render properly
i think it's prudent to disable async for bootstrap css files

<!---
@huboard:{"custom_state":"archived"}
-->
