### PR TITLE
More Robust Admin Check

### DIFF
--- a/class.FlipAdminPage.php
+++ b/class.FlipAdminPage.php
@@ -135,6 +135,11 @@ class FlipAdminPage extends FlipPage
         $this->body .= $card;
     }
 
+    public function isAdmin()
+    {
+        return $this->is_admin;
+    }
+
     public function printPage($header = true)
     {
         if($this->user === false || $this->user === null)
@@ -146,7 +151,7 @@ class FlipAdminPage extends FlipPage
             </div>
         </div>';
         }
-        else if($this->is_admin === false)
+        else if($this->isAdmin() === false)
         {
             $this->body = '
         <div class="row">


### PR DESCRIPTION
With the exception of ProfilesAdminPage all the other Admin pages have a more complicated set of circumstances to view the page (i.e. the ProfilesLeadPage allows both leads and CC to access or the TicketAdminPage allows both TicketAdmins and TicketTeam to access).

This allows for a trivial function override in those child classes rather than having to also override printPage. 