### PR TITLE
Add ability to override serialization in endpoint

### DIFF
--- a/Http/Rest/class.SerializationMiddleware.php
+++ b/Http/Rest/class.SerializationMiddleware.php
@@ -76,12 +76,17 @@ class SerializationMiddleware
         {
             return $response;
         }
-        $request = $request->withAttribute('format', $this->format);
+        $request = $request->withAttribute('format', $this->format)->withAttribute('serializeOverrides', new \Slim\Collection());
         $response = $next($request, $response);
         if($response->getHeaderLine('Content-Type') !== 'application/json;charset=utf-8')
         {
             //The underlying API call gave us back a different content type. Just pass that on...
             return $response;
+        }
+        $overrides = $request->getAttribute('serializeOverrides');
+        if($overrides->has($this->format))
+        {
+            return $this->reserializeBody($response, $overrides->get($this->format));
         }
         switch($this->format)
         {


### PR DESCRIPTION
This adds the ability for an endpoint to provide a class for serialization. I'm using this for the PDF/HTML rendering in the registration stuff. 